### PR TITLE
docs: update readme follow the latest file changes

### DIFF
--- a/nextjs/README.md
+++ b/nextjs/README.md
@@ -38,9 +38,6 @@ import '@react-pdf-viewer/default-layout/lib/styles/index.css';
 import { Viewer, Worker } from '@react-pdf-viewer/core';
 import { defaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
 
-import '@react-pdf-viewer/core/lib/styles/index.css';
-import '@react-pdf-viewer/default-layout/lib/styles/index.css';
-
 const defaultLayoutPluginInstance = defaultLayoutPlugin();
 
 return (


### PR DESCRIPTION
Since we already import the style on _app.js, we don't need to import it again in index.js